### PR TITLE
azure-build-and-publish.yml: track renamed Azure command

### DIFF
--- a/azure-build-and-publish.yml
+++ b/azure-build-and-publish.yml
@@ -87,8 +87,8 @@ jobs:
       azurePowerShellVersion: 'LatestVersion'
       scriptType: 'inlineScript'
       inline: |
-        Unpublish-AzCdnEndpointContent `
+        Clear-AzCdnEndpointContent `
           -ProfileName ${{ parameters.cdnProfileName }} `
           -ResourceGroupName ${{ parameters.cdnResourceGroupName }} `
           -EndpointName ${{ parameters.cdnEndpointName }} `
-          -PurgeContent '${{ parameters.cdnPubPrefix }}/*'
+          -ContentPath @('${{ parameters.cdnPubPrefix }}/*')


### PR DESCRIPTION
This name was changed a while ago. I've fixed the issue in most places but not here, yet, it seems.